### PR TITLE
Adds sort button that toggles between ascending and descending moves

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,9 @@ class Game extends React.Component {
       ],
       stepNumber: 0,
       xIsNext: true,
+      isAsc: true
     };
+
     {/* Array of 9 nulls that correspond to the 9 squares */}  
   }
 
@@ -140,7 +142,10 @@ class Game extends React.Component {
         </div>
         <div className="game-info">
           <div>{status}</div>
-          <ol>{moves}</ol>
+          <ol>{this.state.isAsc ? moves : moves.reverse()}</ol>
+        </div>
+        <div>
+          <button onClick={() => this.setState({isAsc : !this.state.isAsc})}>Re-sort</button>
         </div>
       </div>
     );

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ class Game extends React.Component {
           <ol>{this.state.isAsc ? moves : moves.reverse()}</ol>
         </div>
         <div>
-          <button onClick={() => this.setState({isAsc : !this.state.isAsc})}>Re-sort</button>
+          <button onClick={() => this.setState({isAsc : !this.state.isAsc})}>{this.state.isAsc ? 'Sort by descending' : 'Sort by ascending'}</button>
         </div>
       </div>
     );


### PR DESCRIPTION
# Goal
Create sort button that toggles between ascending and descending moves
Change sort button text so it is clearer if you are in ascending or descending order

# Actual
![sort-moves](https://user-images.githubusercontent.com/36611311/38970224-8f9302b2-43d7-11e8-92b0-393fb1be9844.gif)

# To-do
- [ ] Fix bug that changes format of 'Go to game start' button when you get to the last (10th) move
